### PR TITLE
Skip events that ended in the past

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "launch": "npx http-server"
+  }
+}

--- a/map.js
+++ b/map.js
@@ -44,9 +44,6 @@ async function initialize() {
   window.events.load()
     .then(events => {
       events.forEach(event => {
-        if (!event.title) return; // skip empty events just in case
-        if (!event.geometry) console.error('Event Geometry Missing', { event });
-        if (new Date(event.end_time) < new Date()) return; // skip events that have ended
         event.marker = new google.maps.marker.AdvancedMarkerElement({
           map: window.map,
           position: event.geometry,
@@ -129,11 +126,6 @@ window.filter = function (filters = {}) {
     }
     // check category
     if (categories.length && !event.categories.some(category => categories.includes(category))) {
-      event.visible = false;
-    }
-
-    // check if event has ended
-    if (new Date(event.end_time) < new Date()) {
       event.visible = false;
     }
 
@@ -264,7 +256,7 @@ class Events {
     
     this.cache = window.localStorage.getItem('events');
 
-    if (this.cache)
+    if (this.cache && typeof this.cache === 'string')
       this.cache = JSON.parse(this.cache);
     
     return this.cache;
@@ -277,14 +269,23 @@ class Events {
    * @returns {object[]} events
    */
   set(events) {
+    const now = new Date()
+    // if (!event.title) return; // skip empty events just in case
+    // if (!event.geometry) console.error('Event Geometry Missing', { event });
+    // if (new Date(event.end_time) < new Date()) return; // skip events that have ended
+    const data = events.filter(event => 
+      event.title && 
+      event.geometry && 
+      (!event.end_time || new Date(event.end_time) > now)
+    );
     try {
       // Known to throw QuotaExceededException on Safari
-      window.localStorage.setItem('events', JSON.stringify(events));
+      window.localStorage.setItem('events', JSON.stringify(data));
       window.localStorage.setItem('events_age', Date.now());
     } catch (e) {
       console.error(e)
     }
-    this.cache = events;
+    this.cache = data;
     return this.cache;
   }
 
@@ -330,17 +331,6 @@ class Events {
   query() {
     return fetch(new Request(Events.API))
       .then(response => response.json());
-  }
-
-  /**
-   * Filters out past events based on their end time
-   * 
-   * @param {object[]} events
-   * @returns {object[]} filtered events
-   */
-  filterPastEvents(events) {
-    const now = new Date();
-    return events.filter(event => new Date(event.end_time) >= now);
   }
 }
 

--- a/map.js
+++ b/map.js
@@ -46,6 +46,7 @@ async function initialize() {
       events.forEach(event => {
         if (!event.title) return; // skip empty events just in case
         if (!event.geometry) console.error('Event Geometry Missing', { event });
+        if (new Date(event.end_time) < new Date()) return; // skip events that have ended
         event.marker = new google.maps.marker.AdvancedMarkerElement({
           map: window.map,
           position: event.geometry,
@@ -128,6 +129,11 @@ window.filter = function (filters = {}) {
     }
     // check category
     if (categories.length && !event.categories.some(category => categories.includes(category))) {
+      event.visible = false;
+    }
+
+    // check if event has ended
+    if (new Date(event.end_time) < new Date()) {
       event.visible = false;
     }
 
@@ -324,6 +330,17 @@ class Events {
   query() {
     return fetch(new Request(Events.API))
       .then(response => response.json());
+  }
+
+  /**
+   * Filters out past events based on their end time
+   * 
+   * @param {object[]} events
+   * @returns {object[]} filtered events
+   */
+  filterPastEvents(events) {
+    const now = new Date();
+    return events.filter(event => new Date(event.end_time) >= now);
   }
 }
 

--- a/map.js
+++ b/map.js
@@ -43,7 +43,9 @@ async function initialize() {
   console.log('Loading Events...');
   window.events.load()
     .then(events => {
+      const now = new Date();
       events.forEach(event => {
+        if (new Date(event.end_time) < now) return; // skip events that have ended
         event.marker = new google.maps.marker.AdvancedMarkerElement({
           map: window.map,
           position: event.geometry,
@@ -109,6 +111,8 @@ window.filter = function (filters = {}) {
   if (options.category) {
     categories = options.category.split(',')
   }
+
+  const now = new Date();
     
   // Filter events
   let count = window.events.get().filter(event => {
@@ -124,11 +128,17 @@ window.filter = function (filters = {}) {
       )
         event.visible = false;
     }
+    
     // check category
     if (categories.length && !event.categories.some(category => categories.includes(category))) {
       event.visible = false;
     }
 
+    // check if event has ended
+    if (new Date(event.end_time) < now) {
+      event.visible = false;
+    }
+    
     // if (event.visible) {
     //   event.marker.content.classList.add('drop')
     // } else {


### PR DESCRIPTION
Fixes #16

Skip events that have ended before rendering them on the map.

* Add logic in `map.js` to check if an event has ended before rendering it on the map.
* Update the `filter` function in `map.js` to include logic to check if an event has ended before rendering it on the map.
* Add a method to the `Events` class in `map.js` to filter out past events based on their end time.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ProLoser/funcheapmap/pull/17?shareId=7ccd65e7-945d-4c22-a1ce-550379e33930).